### PR TITLE
Correct case on VanHOzone import

### DIFF
--- a/get_boa_reflectance.py
+++ b/get_boa_reflectance.py
@@ -2,7 +2,7 @@ from LandsatUtils import parse_metadata
 from Py6S import *
 import numpy as np
 import dateutil
-from VanHOzone import get_ozone_conc
+from vanHOzone import get_ozone_conc
 from scipy.interpolate import interp1d
 from functools import wraps
 import logging


### PR DESCRIPTION
Since VanHOzone has been turned into a module, it appears to need a lower-case 'v' to work. I found this out reinstalling everything from scratch on OSX...
